### PR TITLE
Change to relative import for certain files

### DIFF
--- a/filters/create_project.py
+++ b/filters/create_project.py
@@ -25,7 +25,7 @@ from qgis.core import (
     QgsMessageLog,
     QgsVectorLayer,
     QgsRasterLayer)
-from filters.tools import generate_legend
+from .tools import generate_legend
 
 
 class CreateProject(QgsServerFilter):

--- a/filters/map_composition.py
+++ b/filters/map_composition.py
@@ -26,7 +26,7 @@ from qgis.core import (
     QgsMessageLog,
     QgsVectorLayer,
     QgsRasterLayer)
-from tools import generate_legend
+from .tools import generate_legend
 
 
 class MapComposition(QgsServerFilter):

--- a/test/test_create_project.py
+++ b/test/test_create_project.py
@@ -17,7 +17,7 @@
 ***************************************************************************
 """
 
-from base_test import TestServerPlugin
+from .base_test import TestServerPlugin
 TEST_DATA = '/home/etienne/kartoza_dev/server_plugins/otf-project/test/data/'
 
 


### PR DESCRIPTION
Change some import as relative imports by paranoid programming.
It fixes strange behaviour when the plugin is not loaded in my linux. but loaded in my mac, even if both of them uses docker.
